### PR TITLE
feat: added custom labels to vscode tabs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,12 @@
   "files.associations": {
     "*.css": "tailwindcss"
   },
+  "workbench.editor.customLabels.patterns": {
+    "**/app/**/page.tsx": "(${dirname})/page.${extname}",
+    "**/app/**/layout.tsx": "(${dirname})/layout.${extname}",
+    "**/app/**/index.tsx": "(${dirname})/index.${extname}",
+    "**/app/**/route.ts": "(${dirname})/route.${extname}"
+  },
   // Silent the stylistic rules in you IDE, but still auto fix them
   "eslint.rules.customizations": [
     {

--- a/cli/src/templates/extras/vscode/base/_settings.json
+++ b/cli/src/templates/extras/vscode/base/_settings.json
@@ -7,6 +7,12 @@
     "source.fixAll.eslint": "explicit",
     "source.organizeImports": "never"
   },
+  "workbench.editor.customLabels.patterns": {
+    "**/app/**/page.tsx": "(${dirname})/page.${extname}",
+    "**/app/**/layout.tsx": "(${dirname})/layout.${extname}",
+    "**/app/**/index.tsx": "(${dirname})/index.${extname}",
+    "**/app/**/route.ts": "(${dirname})/route.${extname}"
+  },
   "files.associations": {
     "*.css": "tailwindcss"
   },


### PR DESCRIPTION
closes #71 

added to both generated projects and the cli itself (although i've recently disabled vscode tabs, as an experiment)